### PR TITLE
Swagger config to exclude deprecated fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.3.0-SNAPSHOT'
+    version = '1.2.23'
     group = 'grpcbridge'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.2.22'
+    version = '1.3.0-SNAPSHOT'
     group = 'grpcbridge'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.2.21'
+    version = '1.2.22'
     group = 'grpcbridge'
 
     repositories {

--- a/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoDescriptorTraverser.java
@@ -29,11 +29,14 @@ public class ProtoDescriptorTraverser {
     }
 
     private void traverse(List<FieldDescriptor> fields) {
-        fields.forEach(field -> {
-            visitor.onBeforeField(field);
-            onField(field);
-            visitor.onAfterField(field);
-        });
+        fields
+                .stream()
+                .filter(visitor::accept)
+                .forEach(field -> {
+                    visitor.onBeforeField(field);
+                    onField(field);
+                    visitor.onAfterField(field);
+                });
     }
 
     /**

--- a/lib/src/main/java/grpcbridge/util/ProtoVisitor.java
+++ b/lib/src/main/java/grpcbridge/util/ProtoVisitor.java
@@ -63,6 +63,16 @@ public abstract class ProtoVisitor {
     }
 
     /**
+     * Checks if the field is accepted by the visitor.
+     *
+     * @param field a field descriptor
+     * @return true if the field is accepted; false otherwise
+     */
+    public boolean accept(FieldDescriptor field) {
+        return true;
+    }
+
+    /**
      * Invoked at the start of a repeated field.
      *
      * @param field repeated field descriptor

--- a/swagger/src/main/java/grpcbridge/swagger/ModelBuilder.java
+++ b/swagger/src/main/java/grpcbridge/swagger/ModelBuilder.java
@@ -40,6 +40,11 @@ class ModelBuilder extends ProtoVisitor {
     }
 
     @Override
+    public boolean accept(FieldDescriptor field) {
+        return !config.isExcluded(field);
+    }
+
+    @Override
     public void onMessageStart(FieldDescriptor field) {
         models.peek().putProperty(
             config.formatFieldName(field),

--- a/swagger/src/main/java/grpcbridge/swagger/ParametersBuilder.java
+++ b/swagger/src/main/java/grpcbridge/swagger/ParametersBuilder.java
@@ -85,6 +85,11 @@ class ParametersBuilder extends ProtoVisitor {
     }
 
     @Override
+    public boolean accept(FieldDescriptor field) {
+        return !config.isExcluded(field);
+    }
+
+    @Override
     public void onRepeatedFieldStart(FieldDescriptor field) {
         visitingRepeated = true;
         String name = fullPathName(field);

--- a/swagger/src/main/java/grpcbridge/swagger/SwaggerConfig.java
+++ b/swagger/src/main/java/grpcbridge/swagger/SwaggerConfig.java
@@ -5,7 +5,6 @@ import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.GeneratedMessage.GeneratedExtension;
 
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * Configures schema generation. Handles field name formatting and optional extensions.
@@ -13,19 +12,26 @@ import javax.annotation.Nullable;
 class SwaggerConfig {
     private final Set<GeneratedExtension<FieldOptions, Boolean>> requiredExtensions;
     private final FieldNameFormatter formatter;
+    private final boolean excludeDeprecated;
 
     SwaggerConfig(
         Set<GeneratedExtension<FieldOptions, Boolean>> requiredExtensions,
-        FieldNameFormatter formatter
+        FieldNameFormatter formatter,
+        boolean excludeDeprecated
     ) {
         this.requiredExtensions = requiredExtensions;
         this.formatter = formatter;
+        this.excludeDeprecated = excludeDeprecated;
     }
 
     boolean isRequired(FieldDescriptor field) {
         return requiredExtensions
             .stream()
             .anyMatch(extension -> field.getOptions().getExtension(extension));
+    }
+
+    boolean isExcluded(FieldDescriptor field) {
+        return field.getOptions().getDeprecated();
     }
 
     String formatFieldName(FieldDescriptor field) {

--- a/swagger/src/test/java/grpcbridge/swagger/BridgeSwaggerManifestGeneratorTest.java
+++ b/swagger/src/test/java/grpcbridge/swagger/BridgeSwaggerManifestGeneratorTest.java
@@ -27,6 +27,7 @@ public class BridgeSwaggerManifestGeneratorTest {
         String manifest = bridge.generateManifest(
             BridgeSwaggerManifestGenerator.newBuilder()
                 .addRequiredExtension(testRequired)
+                .excludeDeprecated()
                 .build()
         );
         String expected = load("test-proto-swagger.json");

--- a/swagger/src/test/proto/test.proto
+++ b/swagger/src/test/proto/test.proto
@@ -42,7 +42,10 @@ message GetRequest {
   oneof one_of_field {
     string string_one_of = 13;
     Nested message_one_of = 14;
+    Excluded excluded_one_of = 16 [deprecated = true];
   }
+
+  string excluded = 17 [deprecated = true];
 }
 
 message GetResponse {
@@ -64,12 +67,22 @@ message GetResponse {
   oneof one_of_field {
     string string_one_of = 13;
     Nested message_one_of = 14;
+    Excluded excluded_one_of = 18 [deprecated = true];
   }
+
+  string excluded = 19 [deprecated = true];
+}
+
+message Excluded {
+  option deprecated = true;
+  string string_field = 1;
 }
 
 message PostRequest {
   string string_field = 1 [(test_required) = true];
   int32 int_field = 2;
+
+  string excluded = 3 [deprecated = true];
 }
 
 message PostResponse {
@@ -80,6 +93,8 @@ message PostResponse {
 message PostBodyRequest {
   string string_field = 1 [(test_required) = true];
   int32 int_field = 2;
+
+  string excluded = 3 [deprecated = true];
 }
 
 message PostBodyResponse {
@@ -185,4 +200,6 @@ service TestService {
         patch: "/patch/{string_field}"
     };
   }
+
+  rpc NoHttpOption (GetRequest) returns (GetResponse);
 }


### PR DESCRIPTION
swagger config to exclude deprecated fields;
ignore swagger generation for non-http routes.