### PR TITLE
Enables support for 'additional_bindings' option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'idea'
 
-    version = '1.2.24'
+    version = '1.2.25'
     group = 'grpcbridge'
 
     repositories {

--- a/lib/src/test/java/grpcbridge/route/RouteTest.java
+++ b/lib/src/test/java/grpcbridge/route/RouteTest.java
@@ -1,0 +1,77 @@
+package grpcbridge.route;
+
+import static grpcbridge.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import grpcbridge.Bridge;
+import grpcbridge.Exceptions.RouteNotFoundException;
+import grpcbridge.http.HttpRequest;
+import grpcbridge.http.HttpResponse;
+import grpcbridge.test.proto.RouteTest.Empty;
+import grpcbridge.test.proto.RouteTestServiceGrpc.RouteTestServiceImplBase;
+import io.grpc.stub.StreamObserver;
+
+import org.junit.Test;
+
+public class RouteTest {
+    private Bridge bridge = Bridge
+            .builder()
+            .addFile(grpcbridge.test.proto.RouteTest.getDescriptor())
+            .addService(new RouteTestService().bindService())
+            .build();
+
+    @Test
+    public void match_success() {
+        HttpRequest request = HttpRequest
+                .builder(GET, "/get")
+                .build();
+
+        HttpResponse response = bridge.handle(request);
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    public void match_additional() {
+        HttpRequest request = HttpRequest
+                .builder(GET, "/v1/get")
+                .build();
+
+        HttpResponse response = bridge.handle(request);
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    public void match_failure() {
+        HttpRequest request = HttpRequest
+                .builder(GET, "/v2/get")
+                .build();
+
+        assertThatExceptionOfType(RouteNotFoundException.class)
+                .isThrownBy(() -> bridge.handle(request));
+    }
+
+    @Test
+    public void match_no_additional() {
+        HttpRequest request = HttpRequest
+                .builder(GET, "/get2")
+                .build();
+
+        HttpResponse response = bridge.handle(request);
+        assertThat(response).isNotNull();
+    }
+
+    private static final class RouteTestService extends RouteTestServiceImplBase {
+        @Override
+        public void get(Empty request, StreamObserver<Empty> responseObserver) {
+            responseObserver.onNext(Empty.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void getNoAdditional(Empty request, StreamObserver<Empty> responseObserver) {
+            responseObserver.onNext(Empty.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/lib/src/test/proto/route-test.proto
+++ b/lib/src/test/proto/route-test.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+package grpcbridge.test.proto;
+
+import "google/api/annotations.proto";
+
+message Empty {}
+
+service RouteTestService {
+  rpc Get (Empty) returns (Empty) {
+    option (google.api.http) = {
+        get: "/get"
+        additional_bindings {
+          get: "/v1/get"
+        }
+    };
+  }
+
+  rpc GetNoAdditional (Empty) returns (Empty) {
+    option (google.api.http) = {
+        get: "/get2"
+    };
+  }
+}


### PR DESCRIPTION
```
option (google.api.http) = {
  get: "/get"
  additional_bindings {
    get: "/v1/get"
  }
};
```